### PR TITLE
CI: enable github workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,19 +2,16 @@ name: audit
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
 
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.58.1
-            default: true
-            override: true
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.58.1
+      - name: install cargo-audit
+        run: cargo install cargo-audit
+      - name: audit dependencies
+        run: cargo audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
 
 jobs:
@@ -18,19 +18,15 @@ jobs:
           - os: ubuntu-latest
             sanitizer: address
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Rust (regular)
         if: matrix.sanitizer != 'address'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.58.1
-          default: true
+        uses: dtolnay/rust-toolchain@1.58.1
       - name: Setup Rust (for sanitizer)
         if: matrix.sanitizer == 'address'
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2021-12-22
-          default: true
       - name: Settings for cargo in Linux
         if: matrix.sanitizer == 'address'
         run: |
@@ -55,13 +51,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install pkg-config gmp libev libsodium hidapi libffi
       - name: cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        env:
-          LD_LIBRARY_PATH: ${{ github.workspace }}/tezos/sys/lib_tezos/artifacts/
-          DYLD_LIBRARY_PATH: ${{ github.workspace }}/tezos/sys/lib_tezos/artifacts/
-        with:
-          command: test
+        run: cargo test

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,23 +2,16 @@ name: clippy
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
 
 jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
           components: clippy
-          override: true
-
       - name: lint
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -A clippy::too_many_arguments -A clippy::doc_markdown
+        run: cargo clippy --all-targets -- -A clippy::too_many_arguments -A clippy::doc_markdown

--- a/.github/workflows/fuzzcheck.yml
+++ b/.github/workflows/fuzzcheck.yml
@@ -2,11 +2,13 @@ name: fuzzcheck
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
 
+# TODO: enable once 'fuzz/encoding' has been brought up to date
 jobs:
   fuzzcheck:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -2,7 +2,7 @@ name: rustfmt
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
 
 jobs:
@@ -10,13 +10,9 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
-          default: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - name: check formatting
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Enable CI for builds/PRs.

Switches away from `actions-rs` as this is unmaintained. See [thread](https://github.com/actions-rs/toolchain/issues/216)