### PR TITLE
crypto: replace digest implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "anyhow",
  "base58",
  "byteorder",
+ "cryptoxide",
  "ed25519-compact",
  "fuzzcheck",
  "hex",
@@ -193,6 +194,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71fc7b8ebdfe6f948c2b6cc237301846958ba07a0e3fd8bea4a39f22cc94f2c"
 
 [[package]]
 name = "decent-synquote-alternative"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,6 +22,7 @@ strum = "0.20"
 strum_macros = "0.20"
 zeroize = { version = "1.5" }
 ed25519-compact = { version ="2.0", default-features = false }
+cryptoxide = { version = "0.4.3", default-features = false, features = ["sha2"] }
 
 fuzzcheck = { git = "https://github.com/tezedge/fuzzcheck-rs.git", optional = true }
 

--- a/crypto/src/base58.rs
+++ b/crypto/src/base58.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use base58::{FromBase58, ToBase58};
-use sodiumoxide::crypto::hash::sha256;
+use cryptoxide::hashing::sha256;
 use thiserror::Error;
 
 /// Possible errors for base58checked
@@ -33,9 +33,9 @@ pub enum ToBase58CheckError {
 }
 
 /// Create double hash of given binary data
-fn double_sha256(data: &[u8]) -> sha256::Digest {
-    let digest = sha256::hash(data);
-    sha256::hash(digest.as_ref())
+fn double_sha256(data: &[u8]) -> [u8; 32] {
+    let digest = sha256(data);
+    sha256(digest.as_ref())
 }
 
 /// A trait for converting a value to base58 encoded string.


### PR DESCRIPTION
sodiumoxide doesn't support compilation to wasm