### PR TITLE
crypto: add initial bls support

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.58.1
+      - uses: dtolnay/rust-toolchain@1.60.0
       - name: install cargo-audit
         run: cargo install cargo-audit
       - name: audit dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Rust (regular)
         if: matrix.sanitizer != 'address'
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.60.0
         with:
           target: wasm32-unknown-unknown
       - name: Setup Rust (for sanitizer)
         if: matrix.sanitizer == 'address'
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2021-12-22
+          toolchain: nightly-2022-04-07
       - name: Settings for cargo in Linux
         if: matrix.sanitizer == 'address'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,16 +48,21 @@ jobs:
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test
             sudo add-apt-repository "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty main"
             sudo apt-get update -y
-            sudo apt-get install libhidapi-dev libsodium-dev libev4 clang libclang-dev llvm-dev g++
+            sudo apt-get install libhidapi-dev libev4 clang libclang-dev llvm-dev g++
       - name: OSX dependencies
         if: runner.os == 'macOS'
-        run: brew install pkg-config gmp libev libsodium hidapi libffi
+        run: brew install pkg-config gmp libev hidapi libffi
       - name: cargo check (default features)
         run: cargo check
       - name: cargo check (no default features)
         run: cargo check --no-default-features
       - name: cargo test
         run: cargo test
-      - name: cargo build - wasm32
-        if: matrix.sanitizer != 'address'
+      - name: cargo build - wasm32 (OSX)
+        if: runner.os == 'macOS'
+        run: |
+          export PATH=/usr/local/opt/llvm/bin:$PATH
+          cargo check --target wasm32-unknown-unknown --no-default-features
+      - name: cargo build - wasm32 (Linux)
+        if: runner.os == 'linux' && matrix.sanitizer != 'address'
         run: cargo build --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.58.1
+      - uses: dtolnay/rust-toolchain@1.60.0
         with:
           components: clippy
       - name: lint

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.58.1
+      - uses: dtolnay/rust-toolchain@1.60.0
         with:
           components: rustfmt
       - name: check formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +113,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "which",
+ "zeroize",
 ]
 
 [[package]]
@@ -154,6 +176,7 @@ version = "3.1.1"
 dependencies = [
  "anyhow",
  "base58",
+ "blst",
  "byteorder",
  "cryptoxide",
  "ed25519-compact",
@@ -163,6 +186,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "p256",
+ "proptest",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -243,6 +267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +316,12 @@ dependencies = [
  "libz-sys",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
@@ -376,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "group"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -450,6 +501,12 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsecp256k1"
@@ -582,6 +639,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -667,6 +735,39 @@ checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -755,6 +856,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +889,27 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -873,10 +1013,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "tezos_encoding"
@@ -929,10 +1095,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -953,6 +1134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1171,17 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"
@@ -1009,3 +1216,18 @@ name = "zeroize"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -3,7 +3,7 @@ name = "crypto"
 version = "3.1.1"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 
 [dependencies]
 anyhow = "1.0"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,14 +22,15 @@ strum_macros = "0.20"
 zeroize = { version = "1.5" }
 ed25519-compact = { version ="2.0", default-features = false }
 cryptoxide = { version = "0.4.4", default-features = false, features = ["sha2", "blake2"] }
+blst = "0.3.10"
 
 fuzzcheck = { git = "https://github.com/tezedge/fuzzcheck-rs.git", optional = true }
+proptest = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
 
-
 [features]
 default = ["std"]
-std = ["rand/std", "num-bigint/rand", "libsecp256k1/std", "p256/std"]
+std = ["rand/std", "num-bigint/rand", "libsecp256k1/std", "p256/std", "proptest"]
 fuzzing = ["fuzzcheck"]

--- a/crypto/src/base58.rs
+++ b/crypto/src/base58.rs
@@ -1,4 +1,5 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-FileCopyrightText: 2023 TriliTech <contact@trili.tech>
 // SPDX-License-Identifier: MIT
 
 use base58::{FromBase58, ToBase58};

--- a/crypto/src/base58.rs
+++ b/crypto/src/base58.rs
@@ -50,6 +50,7 @@ pub trait FromBase58Check {
     const CHECKSUM_BYTE_SIZE: usize = 4;
 
     /// Convert a value of `self`, interpreted as base58check encoded data, into the tuple with version and payload as bytes vector.
+    #[allow(clippy::wrong_self_convention)]
     fn from_base58check(&self) -> Result<Vec<u8>, FromBase58CheckError>;
 }
 

--- a/crypto/src/bls.rs
+++ b/crypto/src/bls.rs
@@ -1,0 +1,706 @@
+// SPDX-FileCopyrightText: 2022-2023 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! BLS support for the kernel
+//!
+//! Provides signature verification and de-serialization functions for BLS
+//! signatures & public keys.
+//!
+//! Encoding is done via the [Compressed] struct, for compatability with [tezos_encoding],
+//! as deserialization must either succeed, or return a limited number of error types.
+//!
+//! Therefore, we encode using an intermediate structure, and will provide separate logic
+//! covering instances where the encoding succeeds, but the final conversion fails.
+
+use std::fmt::{Debug, Formatter};
+
+use crate::hash::{ContractTz4Hash, TryFromPKError};
+use crate::PublicKeyWithHash;
+use blst::min_pk::{
+    AggregateSignature, PublicKey as BlstPublicKey, SecretKey, Signature as BlstSignature,
+};
+use blst::BLST_ERROR;
+use thiserror::Error;
+
+/// Wrapper for all errors coming from `blst`
+///
+/// Wrapping of the C style return code used by blst. Functions in this
+/// module should avoid ever returning something like `BlsError(BLST_SUCCESS)`.
+#[derive(Debug, PartialEq, Error, Clone)]
+pub struct BlsError(BLST_ERROR);
+
+impl std::fmt::Display for BlsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "BlsError {:?}", self.0)
+    }
+}
+
+/// Transform `blst` errors to Rust `Result`.
+///
+/// Go from `BLST_ERROR` to normal Rust `Result`, where a success is
+/// interpreted as true, ie, it is true that signature is valid and
+/// false means signature is invalid. Errors can be caused by invalid
+/// public keys, et.c.
+fn bool_result_from(blst_error: BLST_ERROR) -> Result<bool, BlsError> {
+    match blst_error {
+        BLST_ERROR::BLST_SUCCESS => Ok(true),
+        BLST_ERROR::BLST_VERIFY_FAIL => Ok(false),
+        _ => Err(BlsError(blst_error)),
+    }
+}
+
+/// Wrap a `blst` signature
+///
+/// The signature can be verified together with a message and [PublicKey].
+#[derive(Debug, PartialEq)]
+pub struct Signature(BlstSignature);
+
+/// Wrap `blst` public key
+///
+/// Use with a [Signature] for verification.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PublicKey(BlstPublicKey);
+
+impl PublicKey {
+    /// The length in bytes of a compressed [BlstPublicKey].
+    pub const COMPRESSED_SIZE: usize = 48;
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<[u8; 48]> for PublicKey {
+    fn into(self) -> [u8; 48] {
+        self.0.to_bytes()
+    }
+}
+
+/// A message and a public key for this message.
+///
+/// This follows the `aggregate_verify` calling convention used for TORU.
+/// Not currently being used, but the mode is available in the tezos protocol.
+pub type Message<'a> = (&'a [u8], &'a PublicKey);
+
+/// Basic `dst` parameter for `blst`
+///
+/// Same constant as used for `Basic` in `bls12-381` ocaml package used in tezos.
+#[allow(dead_code)]
+const BASIC_CIPHER_SUITE: &str = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
+
+/// Aug `dst` parameter for `blst`
+///
+/// Same constant as used for `Basic` in `bls12-381` ocaml package used in tezos.
+/// This is the mode used for TORU.
+const AUG_CIPHER_SUITE: &str = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
+
+/// Pop signatures parameter value for `blst`
+///
+/// Same constant as used for verify `Pop` in `bls12-381` ocaml package used in tezos.
+/// Not currently being used, but the mode is available in the tezos protocol.
+#[allow(dead_code)]
+const POP_CIPHER_SUITE: &str = "BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+impl Signature {
+    /// The length in bytes of a compressed [BlstSignature].
+    pub const COMPRESSED_SIZE: usize = 96;
+
+    /// Verify several messages with public keys and _one_ signature.
+    ///
+    /// Verify a signature for one or more messages. The signature must have been
+    /// constructed by *only* the given messages.
+    ///
+    /// When verifying, we also check the public keys and group check. Like Tezos_crypto,
+    /// this verification function uses the Aug suite.
+    pub fn aggregate_verify<'a>(
+        &self,
+        messages: &mut impl Iterator<Item = Message<'a>>,
+    ) -> Result<bool, BlsError> {
+        let (messages, public_keys): (Vec<_>, Vec<_>) = messages
+            .map(|(message, public_key)| {
+                // For saftey, we ensure that each message is unique by prepending the
+                // public key.
+                let message_with_pk = prepend_public_key(message, public_key);
+
+                (message_with_pk, &public_key.0)
+            })
+            .unzip();
+
+        let messages = messages.iter().map(Vec::as_slice).collect::<Vec<_>>();
+
+        // Tezos_crypto uses the Aug suite
+        let dst = AUG_CIPHER_SUITE.as_bytes();
+
+        bool_result_from(
+            self.0
+                .aggregate_verify(true, &messages, dst, &public_keys, true),
+        )
+    }
+
+    /// Aggregate individual signatures into a single signature.
+    pub fn aggregate_sigs(sigs: &[&Self]) -> Result<Self, BlsError> {
+        let sigs: Vec<_> = sigs.iter().map(|Self(s)| s).collect();
+
+        let aggregate = AggregateSignature::aggregate(sigs.as_slice(), true).map_err(BlsError)?;
+
+        aggregate.validate().map_err(BlsError)?;
+
+        Ok(Signature(aggregate.to_signature()))
+    }
+}
+
+/// Compressed version of `T` in bytes of a known length; used for encoding.
+///
+/// It may freely be deserialized to/from bytes, but must be validated when
+/// uncompressing into `T`.
+pub struct Compressed<T, const COMPRESSED_SIZE: usize> {
+    compressed: [u8; COMPRESSED_SIZE],
+    phantom: core::marker::PhantomData<T>,
+}
+
+#[allow(clippy::from_over_into)]
+impl<T, const COMPRESSED_SIZE: usize> Into<String> for Compressed<T, { COMPRESSED_SIZE }> {
+    fn into(self) -> String {
+        hex::encode(self.compressed)
+    }
+}
+
+impl<T, const COMPRESSED_SIZE: usize> TryFrom<String> for Compressed<T, { COMPRESSED_SIZE }> {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let compressed: [u8; COMPRESSED_SIZE] = hex::decode(value)
+            .expect("valid hex")
+            .try_into()
+            .expect("correct length");
+        Ok(Self {
+            compressed,
+            phantom: core::marker::PhantomData,
+        })
+    }
+}
+
+// Manual impl of `Copy + Clone` required, as auto-derive places bounds on `T`,
+// which in this case should be avoided as `T` is only used within `PhantomData`.
+impl<T, const COMPRESSED_SIZE: usize> Clone for Compressed<T, { COMPRESSED_SIZE }> {
+    fn clone(&self) -> Self {
+        Self {
+            compressed: self.compressed,
+            phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, const COMPRESSED_SIZE: usize> Copy for Compressed<T, { COMPRESSED_SIZE }> {}
+
+impl<T, const COMPRESSED_SIZE: usize> core::cmp::PartialEq for Compressed<T, { COMPRESSED_SIZE }> {
+    fn eq(&self, other: &Self) -> bool {
+        self.compressed == other.compressed
+    }
+}
+
+impl<T, const COMPRESSED_SIZE: usize> Eq for Compressed<T, { COMPRESSED_SIZE }> {}
+
+impl<T, const COMPRESSED_SIZE: usize> AsRef<[u8; COMPRESSED_SIZE]>
+    for Compressed<T, { COMPRESSED_SIZE }>
+{
+    fn as_ref(&self) -> &[u8; COMPRESSED_SIZE] {
+        &self.compressed
+    }
+}
+
+macro_rules! compressed {
+    ($uncompress:ty, $inner:ty, $compressed:ident, $compressed_size:expr) => {
+        /// See [Compressed].
+        pub type $compressed = Compressed<$uncompress, $compressed_size>;
+
+        impl $compressed {
+            /// Size in bytes
+            pub const COMPRESSED_SIZE: usize = $compressed_size;
+        }
+
+        impl TryFrom<&$compressed> for $uncompress {
+            type Error = BlsError;
+
+            fn try_from(c: &$compressed) -> Result<Self, Self::Error> {
+                Ok(Self(
+                    <$inner>::from_bytes(c.compressed.as_slice()).map_err(BlsError)?,
+                ))
+            }
+        }
+
+        impl TryFrom<$compressed> for $uncompress {
+            type Error = BlsError;
+
+            fn try_from(c: $compressed) -> Result<Self, Self::Error> {
+                Ok(Self(
+                    <$inner>::from_bytes(c.compressed.as_slice()).map_err(BlsError)?,
+                ))
+            }
+        }
+
+        impl From<&$uncompress> for $compressed {
+            fn from(value: &$uncompress) -> $compressed {
+                Self {
+                    compressed: value.0.compress(),
+                    phantom: core::marker::PhantomData,
+                }
+            }
+        }
+
+        impl From<$uncompress> for $compressed {
+            fn from(value: $uncompress) -> $compressed {
+                Self {
+                    compressed: value.0.compress(),
+                    phantom: core::marker::PhantomData,
+                }
+            }
+        }
+
+        impl From<[u8; $compressed_size]> for $compressed {
+            fn from(value: [u8; $compressed_size]) -> $compressed {
+                Self {
+                    compressed: value,
+                    phantom: core::marker::PhantomData,
+                }
+            }
+        }
+
+        impl TryFrom<[u8; $compressed_size]> for $uncompress {
+            type Error = BlsError;
+
+            fn try_from(value: [u8; $compressed_size]) -> Result<Self, Self::Error> {
+                let compressed = <$compressed>::from(value);
+                (&compressed).try_into()
+            }
+        }
+    };
+}
+
+compressed!(Signature, BlstSignature, CompressedSignature, {
+    Signature::COMPRESSED_SIZE
+});
+compressed!(PublicKey, BlstPublicKey, CompressedPublicKey, {
+    PublicKey::COMPRESSED_SIZE
+});
+
+impl PublicKeyWithHash for CompressedPublicKey {
+    type Hash = ContractTz4Hash;
+    type Error = TryFromPKError;
+
+    fn pk_hash(&self) -> Result<Self::Hash, Self::Error> {
+        let hash = crate::blake2b::digest_160(&self.compressed)?;
+        let typed_hash = Self::Hash::try_from(hash.as_slice())?;
+        Ok(typed_hash)
+    }
+}
+
+impl Debug for CompressedPublicKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self.pk_hash() {
+            Ok(hash) => {
+                write!(f, "CompressedPK(\"{}\")", hash.to_base58_check())
+            }
+            Err(e) => write!(f, "CompressedPK(<hash unavailable: {:?}>)", e),
+        }
+    }
+}
+
+impl Debug for CompressedSignature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "CompressedSignature({:?})", self.compressed)
+    }
+}
+
+/// Wrapper of a [SecretKey], alongside its public key.
+#[derive(Clone)]
+pub struct BlsKey {
+    sk: SecretKey,
+    pk: PublicKey,
+    cpk: CompressedPublicKey,
+    pk_hash: ContractTz4Hash,
+}
+
+impl BlsKey {
+    /// Public key of the contained secret key.
+    pub fn public_key(&self) -> &PublicKey {
+        &self.pk
+    }
+
+    /// Compressed public key of the contained secret key.
+    pub fn compressed_public_key(&self) -> &CompressedPublicKey {
+        &self.cpk
+    }
+
+    /// Hash of the public key - a.k.a a *Layer 2* address.
+    pub fn public_key_hash(&self) -> &ContractTz4Hash {
+        &self.pk_hash
+    }
+
+    /// Sign a message, using the *aug* cipher suite.
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        let message_with_pk = prepend_public_key(msg, &self.pk);
+
+        Signature(
+            self.sk
+                .sign(&message_with_pk, AUG_CIPHER_SUITE.as_bytes(), &[]),
+        )
+    }
+
+    /// Deterministically generate a `BlsKey` from initial key material.
+    pub fn from_ikm(ikm: [u8; 32]) -> Self {
+        let sk = SecretKey::key_gen(&ikm, &[]).unwrap();
+        let pk = PublicKey(sk.sk_to_pk());
+        let cpk: CompressedPublicKey = (&pk).into();
+        let pk_hash = cpk.pk_hash().unwrap();
+
+        BlsKey {
+            sk,
+            pk,
+            cpk,
+            pk_hash,
+        }
+    }
+}
+
+impl PartialEq for BlsKey {
+    /// Equality by comparison of [ContractTz4Hash].
+    fn eq(&self, other: &Self) -> bool {
+        self.pk_hash == other.pk_hash
+    }
+}
+
+impl Debug for BlsKey {
+    /// Debug [BlsKey] must not expose the [SecretKey].
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "BlsKey(\"{}\")",
+            self.public_key_hash().to_base58_check()
+        )
+    }
+}
+
+// We prepend each message with the public key used to sign it.
+fn prepend_public_key(msg: &[u8], pk: &PublicKey) -> Vec<u8> {
+    let mut message_with_pk = Vec::with_capacity(msg.len() + PublicKey::COMPRESSED_SIZE);
+    message_with_pk.extend_from_slice(&pk.0.compress());
+    message_with_pk.extend_from_slice(msg);
+    message_with_pk
+}
+
+#[cfg(any(test, feature = "rand"))]
+mod bls_gen {
+    //! Generation of Bls keys used for testing.
+    //!
+    //! Use
+    //! - `key in BlsKey::arb()` during Property Based Tests.
+    //! - `let key: BlsKey = Faker.fake()` in unit tests, when hardcoding a key is
+    //!   undesirable.
+    use super::*;
+    use proptest::prelude::*;
+    use rand::Rng;
+
+    impl BlsKey {
+        /// Generate arbitrary bls keys for testing
+        pub fn arb() -> BoxedStrategy<BlsKey> {
+            any::<[u8; 32]>().prop_map(Self::from_ikm).boxed()
+        }
+
+        /// Generate random bls key
+        pub fn generate() -> Self {
+            let ikm = rand::thread_rng().gen::<[u8; 32]>();
+            Self::from_ikm(ikm)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlsKey, CompressedPublicKey};
+    use crate::bls::Signature;
+    use crate::{
+        base58::FromBase58Check,
+        hash::{ContractTz4Hash, HashTrait},
+        PublicKeyWithHash,
+    };
+    use proptest::prelude::*;
+
+    #[test]
+    fn decoding_invalid_signature_gives_error() {
+        use super::{BlsError, Signature};
+        use blst::BLST_ERROR;
+
+        let bytes: [u8; 96] = [
+            212, 164, 10, 104, 205, 205, 23, 255, 218, 184, 156, 159, 150, 133, 185, 31, 221, 34,
+            11, 39, 189, 17, 16, 28, 109, 72, 109, 48, 239, 105, 121, 121, 100, 149, 1, 168, 106,
+            118, 145, 148, 182, 122, 206, 83, 8, 214, 146, 238, 181, 41, 182, 23, 221, 66, 47, 99,
+            179, 9, 195, 96, 141, 204, 99, 53, 222, 157, 64, 102, 177, 118, 26, 240, 235, 189, 109,
+            214, 229, 77, 77, 24, 53, 136, 220, 124, 102, 108, 5, 241, 185, 98, 145, 206, 121, 169,
+            11, 255,
+        ];
+
+        let sig = Signature::try_from(bytes);
+
+        assert_eq!(sig, Err(BlsError(BLST_ERROR::BLST_BAD_ENCODING)));
+    }
+
+    #[test]
+    fn decoding_valid_signature_is_ok() {
+        use super::Signature;
+
+        let bytes: [u8; 96] = [
+            149, 240, 234, 160, 166, 30, 18, 15, 229, 113, 68, 192, 204, 118, 169, 78, 252, 237,
+            251, 111, 240, 127, 236, 68, 231, 114, 243, 76, 61, 156, 148, 34, 203, 153, 6, 255,
+            159, 108, 21, 71, 163, 120, 87, 133, 239, 135, 225, 127, 14, 126, 215, 20, 107, 206,
+            222, 198, 187, 11, 173, 56, 167, 119, 182, 55, 57, 102, 180, 194, 18, 91, 49, 59, 130,
+            39, 33, 103, 243, 211, 156, 164, 53, 160, 255, 198, 58, 2, 124, 121, 201, 44, 139, 167,
+            48, 52, 211, 178,
+        ];
+
+        let sig = Signature::try_from(bytes);
+
+        assert!(sig.is_ok());
+    }
+
+    #[test]
+    fn return_error_on_invalid_public_key_encoding() {
+        use super::{BlsError, PublicKey};
+        use blst::BLST_ERROR;
+
+        let bytes: [u8; 48] = [
+            118, 187, 155, 125, 42, 190, 144, 143, 145, 250, 125, 184, 90, 9, 210, 24, 202, 72, 22,
+            137, 121, 174, 233, 107, 175, 63, 167, 107, 192, 38, 60, 102, 74, 213, 169, 88, 51,
+            181, 190, 79, 226, 209, 166, 137, 54, 88, 14, 28,
+        ];
+
+        let pk = PublicKey::try_from(bytes);
+
+        assert_eq!(pk, Err(BlsError(BLST_ERROR::BLST_BAD_ENCODING)));
+    }
+
+    #[test]
+    fn decode_valid_public_key_is_ok() {
+        use super::PublicKey;
+
+        let bytes: [u8; 48] = [
+            145, 150, 3, 232, 142, 40, 236, 191, 116, 53, 15, 47, 240, 143, 182, 94, 110, 121, 160,
+            108, 247, 42, 34, 231, 133, 156, 81, 111, 62, 109, 59, 223, 198, 220, 89, 7, 173, 251,
+            241, 82, 161, 86, 161, 40, 141, 57, 145, 123,
+        ];
+
+        let pk = PublicKey::try_from(bytes);
+
+        assert!(pk.is_ok());
+    }
+
+    #[test]
+    fn can_verify_signature_is_true() {
+        use super::{PublicKey, Signature, AUG_CIPHER_SUITE};
+        use blst::min_pk::SecretKey;
+
+        let ikm: [u8; 32] = [
+            206, 83, 215, 142, 19, 242, 183, 160, 92, 186, 87, 192, 89, 109, 82, 0, 17, 60, 248,
+            194, 149, 144, 24, 238, 202, 18, 75, 107, 139, 241, 104, 198,
+        ];
+
+        let sk = SecretKey::key_gen(&ikm, &[]).unwrap();
+        let pk = PublicKey(sk.sk_to_pk());
+
+        let dst = AUG_CIPHER_SUITE.as_bytes();
+
+        let msg = b"blst is such a blast";
+        let mut signed_bytes = Vec::new();
+        signed_bytes.extend_from_slice(&pk.0.compress());
+        signed_bytes.extend_from_slice(msg);
+
+        let sig = Signature(sk.sign(&signed_bytes, dst, &[]));
+
+        let msg_keys = [(&msg[..], &pk)];
+        let res = sig.aggregate_verify(&mut msg_keys.into_iter());
+
+        assert_eq!(res, Ok(true));
+    }
+
+    // Values taken from tezt test, that was failing due to public key not being
+    // prepended to msg.
+    #[test]
+    fn bls_sign_with_public_key() {
+        use super::*;
+
+        let ikm = [0; 32];
+        let key = BlsKey::from_ikm(ikm);
+
+        assert_eq!(
+            "tz4TpX5Qb3w7xnnnwSpjFs7Kq35GC4qr3uMg",
+            &key.pk_hash.to_base58_check(),
+            "expected addresses to match"
+        );
+
+        let expected_pk_bytes = &[
+            166, 149, 173, 50, 93, 252, 126, 17, 145, 251, 201, 241, 134, 245, 142, 255, 66, 166,
+            52, 2, 151, 49, 177, 131, 128, 255, 137, 191, 66, 196, 100, 164, 44, 184, 202, 85, 178,
+            0, 240, 81, 245, 127, 30, 24, 147, 198, 135, 89,
+        ];
+
+        let actual_pk_bytes = CompressedPublicKey::from(&key.pk).compressed;
+        assert_eq!(expected_pk_bytes, &actual_pk_bytes, "expected pk to match");
+
+        let msg_bytes = &[
+            0, 0, 0, 141, 0, 166, 149, 173, 50, 93, 252, 126, 17, 145, 251, 201, 241, 134, 245,
+            142, 255, 66, 166, 52, 2, 151, 49, 177, 131, 128, 255, 137, 191, 66, 196, 100, 164, 44,
+            184, 202, 85, 178, 0, 240, 81, 245, 127, 30, 24, 147, 198, 135, 89, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 80, 0, 241, 81, 248, 184, 241, 123, 33, 174, 242, 58, 123, 212, 112,
+            246, 137, 34, 107, 182, 199, 80, 7, 7, 10, 0, 0, 0, 22, 1, 98, 180, 106, 212, 106, 51,
+            26, 188, 121, 202, 100, 202, 43, 197, 198, 234, 211, 47, 205, 180, 0, 7, 7, 1, 0, 0, 0,
+            1, 82, 0, 143, 6, 0, 0, 0, 15, 114, 101, 99, 101, 105, 118, 101, 95, 116, 105, 99, 107,
+            101, 116, 115,
+        ];
+
+        let sig = key.sign(msg_bytes);
+
+        let expected_sig = &[
+            170, 60, 254, 35, 122, 181, 133, 165, 130, 161, 54, 157, 133, 39, 163, 49, 146, 56, 61,
+            74, 35, 132, 225, 148, 164, 71, 198, 188, 66, 209, 192, 174, 163, 157, 81, 131, 94,
+            154, 42, 8, 96, 122, 180, 162, 81, 68, 181, 240, 11, 73, 110, 14, 205, 72, 139, 77,
+            134, 106, 133, 253, 138, 75, 56, 85, 188, 232, 58, 186, 100, 124, 234, 69, 200, 163,
+            162, 173, 252, 147, 139, 60, 247, 86, 162, 6, 65, 142, 190, 178, 244, 190, 137, 30, 37,
+            32, 238, 240,
+        ];
+
+        let actual_sig = CompressedSignature::from(sig);
+
+        assert_eq!(
+            expected_sig, &actual_sig.compressed,
+            "expected signatures to match"
+        );
+    }
+
+    #[test]
+    fn can_verify_signature_is_false() {
+        use super::{PublicKey, Signature};
+        use blst::min_pk::SecretKey;
+
+        let ikm: [u8; 32] = [
+            139, 238, 61, 128, 196, 109, 58, 44, 13, 240, 207, 148, 246, 216, 242, 161, 132, 197,
+            169, 201, 120, 146, 252, 112, 92, 255, 57, 102, 202, 178, 210, 113,
+        ];
+
+        let signature_bytes: [u8; 96] = [
+            149, 240, 234, 160, 166, 30, 18, 15, 229, 113, 68, 192, 204, 118, 169, 78, 252, 237,
+            251, 111, 240, 127, 236, 68, 231, 114, 243, 76, 61, 156, 148, 34, 203, 153, 6, 255,
+            159, 108, 21, 71, 163, 120, 87, 133, 239, 135, 225, 127, 14, 126, 215, 20, 107, 206,
+            222, 198, 187, 11, 173, 56, 167, 119, 182, 55, 57, 102, 180, 194, 18, 91, 49, 59, 130,
+            39, 33, 103, 243, 211, 156, 164, 53, 160, 255, 198, 58, 2, 124, 121, 201, 44, 139, 167,
+            48, 52, 211, 178,
+        ];
+
+        let sk = SecretKey::key_gen(&ikm, &[]).unwrap();
+        let pk = PublicKey(sk.sk_to_pk());
+
+        let msg = b"blst is such a blast";
+        let sig = Signature::try_from(signature_bytes);
+
+        assert!(sig.is_ok());
+
+        let msg_keys = [(&msg[..], &pk)];
+        let res = sig.unwrap().aggregate_verify(&mut msg_keys.into_iter());
+
+        assert_eq!(res, Ok(false));
+    }
+
+    // Test to ensure that we use the correct hashing scheme to convert between
+    // bls::PublicKey and ContractTz4Hash.
+    //
+    // Test cases generated using protocol unit tests for tx_rollup.
+    #[test]
+    fn ensure_public_key_hashing_correct() {
+        let test_cases = [
+            (
+                "BLpk1mJXuRWVxRJRkUES7E16u4KeKMGibFtR995FxSFzeyMm8ckngdo4Cx4P3KWeRQ1NeY3iEWwq",
+                "tz4NPp9xHJMgoRQwE2iL66NnfeBcnEoskeuj",
+            ),
+            (
+                "BLpk1wEURk8sJBP2QvjNnjFiFbqJJfRYSKAjHJXbAD9rU1h4wpn8Q1wUAsVXGK3bRrLvhT8f5o3z",
+                "tz492MCfwp9V961DhNGmKzD642uhU8j6H5nB",
+            ),
+            (
+                "BLpk1pJuYBQjSb1JhnfNTkAr2AJ4BhcMdTfyQBK97EHLMukaCWkqpGNxP6fkpZcmLbux7UPNqJhP",
+                "tz4Vc8F1uDc5vxppuWhAvu2HpjsFYS5x5qat",
+            ),
+            (
+                "BLpk1rk1RFdkPgdv5V2PDmxnL3gDeUcQCmH241rGb8YeRqtpAHPnWeUGkvBmzurXCKJJZEsHrjL8",
+                "tz4FJr811sHV649iKrFFgrFM7mvSYBQSKHsP",
+            ),
+        ];
+
+        let run_test = |(pk_b58, tz4_b58): (&str, &str)| {
+            let pk_bytes = pk_b58.from_base58check().expect("Valid pk b58");
+            let pk_bytes: [u8; 48] = pk_bytes[4..] // remove prefix of `BLpk`
+                .try_into()
+                .expect("pk_bytes should be 48 bytes long");
+            let cpk = CompressedPublicKey::try_from(pk_bytes).expect("Valid pk bytes");
+
+            let tz4 = cpk.pk_hash().expect("CompressedPublicKey hashable");
+
+            let expected_tz4 = ContractTz4Hash::from_b58check(tz4_b58).expect("Valid tz4 b58");
+
+            assert_eq!(expected_tz4, tz4);
+        };
+
+        test_cases.into_iter().for_each(run_test);
+    }
+
+    proptest! {
+      #[test]
+      fn verify_signature_of_single_pk(key in BlsKey::arb(), msg in any::<Vec<u8>>()) {
+          let sig = key.sign(msg.as_slice());
+
+          let msg_keys = [(msg.as_slice(), &key.pk)];
+
+          let res = sig.aggregate_verify(&mut msg_keys.into_iter());
+
+          assert_eq!(res, Ok(true));
+      }
+
+      #[test]
+      fn verify_aggregate_signature(
+          fst_key in BlsKey::arb(),
+          snd_key in BlsKey::arb(),
+          fst_msg in any::<Vec<u8>>(),
+          snd_msg in any::<Vec<u8>>(),
+      ) {
+          let sig1 = fst_key.sign(fst_msg.as_slice());
+          let sig2 = fst_key.sign(snd_msg.as_slice());
+          let sig3 = snd_key.sign(fst_msg.as_slice());
+          let sig4 = snd_key.sign(snd_msg.as_slice());
+
+          let sig = Signature::aggregate_sigs(&[&sig1, &sig2, &sig3, &sig4])
+              .expect("aggregation should work");
+
+          let msg_keys = [
+              (fst_msg.as_slice(), &fst_key.pk),
+              (snd_msg.as_slice(), &fst_key.pk),
+              (fst_msg.as_slice(), &snd_key.pk),
+              (snd_msg.as_slice(), &snd_key.pk),
+          ];
+
+          let res = sig.aggregate_verify(&mut msg_keys.into_iter());
+
+          assert_eq!(res, Ok(true));
+      }
+
+      #[test]
+      fn verify_signature_fails_with_wrong_pk(
+          signing_key in BlsKey::arb(),
+          other_key in BlsKey::arb(),
+          msg in any::<Vec<u8>>()
+      ) {
+          let sig = signing_key.sign(msg.as_slice());
+
+          let msg_keys = [(msg.as_slice(), &other_key.pk)];
+
+          let res = sig.aggregate_verify(&mut msg_keys.into_iter());
+
+          assert_eq!(res, Ok(false));
+      }
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 #[macro_use]
 pub mod blake2b;
 pub mod base58;
+pub mod bls;
 #[macro_use]
 pub mod hash;
 

--- a/tezos-encoding-derive/Cargo.toml
+++ b/tezos-encoding-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "tezos_encoding_derive"
 version = "3.1.1"
 authors = ["Alexander Koptelov <alexandre.koptelov@simplestaking.com>"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/tezos-encoding-derive/src/make.rs
+++ b/tezos-encoding-derive/src/make.rs
@@ -1,4 +1,5 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-FileCopyrightText: 2023 TriliTech <contact@trili.tech>
 // SPDX-License-Identifier: MIT
 
 use proc_macro2::Span;
@@ -148,7 +149,7 @@ fn make_basic_encoding_from_type<'a>(
         // String type is mapped to String encoding.
         let string_attr =
             get_attribute_with_option(meta, &symbol::STRING, Some(&symbol::MAX), true)?;
-        Encoding::String(string_attr.map(|param| param.param).flatten(), ident.span())
+        Encoding::String(string_attr.and_then(|param| param.param), ident.span())
     } else if ident == symbol::rust::I64 && has_attribute(meta, &symbol::TIMESTAMP) {
         if let Some(timestamp) = get_attribute_no_param(meta, &symbol::TIMESTAMP)? {
             Encoding::Primitive(PrimitiveEncoding::Timestamp, timestamp.span)
@@ -514,7 +515,7 @@ fn assert_empty_meta(meta: &[syn::Meta]) -> Result<()> {
     }
 }
 
-fn has_attribute(meta: &mut Vec<syn::Meta>, name: &symbol::Symbol) -> bool {
+fn has_attribute(meta: &mut [syn::Meta], name: &symbol::Symbol) -> bool {
     match meta.last() {
         Some(syn::Meta::Path(path)) if path == *name => true,
         Some(syn::Meta::NameValue(name_value)) if name_value.path == *name => true,

--- a/tezos-encoding/Cargo.toml
+++ b/tezos-encoding/Cargo.toml
@@ -3,7 +3,7 @@ name = "tezos_encoding"
 version = "3.1.1"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 
 [dependencies]
 bit-vec = "0.6.2"

--- a/tezos-encoding/src/enc.rs
+++ b/tezos-encoding/src/enc.rs
@@ -12,6 +12,8 @@ pub use tezos_encoding_derive::BinWriter;
 
 use thiserror::Error;
 
+use crypto::bls::Compressed as BlsCompressed;
+
 #[derive(Debug, Error)]
 /// Encoding error kind.
 pub enum BinErrorKind {
@@ -354,6 +356,13 @@ encode_hash!(crypto::hash::SmartRollupHash);
 impl BinWriter for Mutez {
     fn bin_write(&self, out: &mut Vec<u8>) -> BinResult {
         n_bignum(self.0.magnitude(), out)
+    }
+}
+
+impl<T, const COMPRESSED_SIZE: usize> BinWriter for BlsCompressed<T, { COMPRESSED_SIZE }> {
+    fn bin_write(&self, output: &mut Vec<u8>) -> BinResult {
+        output.extend_from_slice(self.as_ref());
+        Ok(())
     }
 }
 

--- a/tezos-encoding/src/encoding.rs
+++ b/tezos-encoding/src/encoding.rs
@@ -3,6 +3,7 @@
 
 //! Schema used for serialization and deserialization.
 
+use crypto::bls::Compressed as BlsCompressed;
 use crypto::hash::{HashTrait, HashType};
 use std::collections::HashMap;
 
@@ -337,6 +338,12 @@ hash_has_encoding!(PublicKeyP256, PUBLIC_KEY_P256);
 hash_has_encoding!(Signature, SIGNATURE);
 hash_has_encoding!(NonceHash, NONCE_HASH);
 hash_has_encoding!(SmartRollupHash, SMART_ROLLUP_HASH);
+
+impl<T, const COMPRESSED_SIZE: usize> HasEncoding for BlsCompressed<T, { COMPRESSED_SIZE }> {
+    fn encoding() -> Encoding {
+        Encoding::Custom
+    }
+}
 
 /// Creates impl HasEncoding for given struct backed by lazy_static ref instance with encoding.
 #[macro_export]

--- a/tezos-encoding/src/nom.rs
+++ b/tezos-encoding/src/nom.rs
@@ -1,6 +1,8 @@
 // Copyright (c) SimpleStaking, Viable Systems, TriliTech, Nomadic Labs and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use crypto::bls::CompressedPublicKey as BlsCompressedPublicKey;
+use crypto::bls::CompressedSignature as BlsCompressedSignature;
 use crypto::hash::HashTrait;
 use nom::{
     bitvec::{bitvec, order::Msb0, view::BitView},
@@ -275,6 +277,32 @@ impl NomReader for Mutez {
         map(n_bignum, |big_uint| {
             BigInt::from_biguint(Sign::Plus, big_uint).into()
         })(bytes)
+    }
+}
+
+impl NomReader for BlsCompressedPublicKey {
+    fn nom_read(input: &[u8]) -> NomResult<Self> {
+        sized(
+            Self::COMPRESSED_SIZE,
+            map(rest, |input: &[u8]| {
+                let mut bytes = [0; Self::COMPRESSED_SIZE];
+                bytes.copy_from_slice(input);
+                Self::from(bytes)
+            }),
+        )(input)
+    }
+}
+
+impl NomReader for BlsCompressedSignature {
+    fn nom_read(input: &[u8]) -> NomResult<Self> {
+        sized(
+            Self::COMPRESSED_SIZE,
+            map(rest, |input: &[u8]| {
+                let mut bytes = [0; Self::COMPRESSED_SIZE];
+                bytes.copy_from_slice(input);
+                Self::from(bytes)
+            }),
+        )(input)
     }
 }
 


### PR DESCRIPTION
Code copied from `tezos/kernel`.

There will be a follow-up MR to integration it better with the rest of the tezedge crates.