### PR TITLE
Revert "crypto: synchronise blst version with octez"

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ strum_macros = "0.20"
 zeroize = { version = "1.5" }
 ed25519-compact = { version ="2.0", default-features = false }
 cryptoxide = { version = "0.4.4", default-features = false, features = ["sha2", "blake2"] }
-blst = "0.3.7"
+blst = "0.3.10"
 
 fuzzcheck = { git = "https://github.com/tezedge/fuzzcheck-rs.git", optional = true }
 proptest = { version = "1.0", optional = true }


### PR DESCRIPTION
This reverts commit 799a678c3d70bf7f3da01e64740e6deee5feacac. Blst cannot be downgraded, without also downgrading zeroize to a version with a known RUSTSEC issue