### PR TITLE
CI: publish all crates in workspace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.60.0
-      - name: dry-run
-        run: cargo publish --dry-run
-      - name: publish
-        run: cargo publish --token ${CRATES_TOKEN}
+      - name: dry-run (crypto)
+        run: cargo publish --dry-run -p tezos_crypto
+      - name: dry-run (derive)
+        run: cargo publish --dry-run -p tezos_data_encoding_derive
+      - name: dry-run (encoding)
+        run: cargo publish --dry-run -p tezos_data_encoding
+      - name: publish (crypto)
+        run: cargo publish -p tezos_crypto --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+      - name: publish (derive)
+        run: cargo publish -p tezos_data_encoding_derive --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+      - name: publish (encoding)
+        run: cargo publish -p tezos_data_encoding --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Nothing.
 
+## [4.0.1] - 2023-03-14
+
+### Changed
+
+- `tezos_encoding` renamed to `tezos_data_encoding`
+- `tezos_encoding_derive` renamed to `tezos_data_encoding_derive`
+
 ## [4.0.0] - 2023-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TezEdge [![Changelog][changelog-badge]][changelog] [![MIT licensed]][MIT link]
+# TezEdge
 
 ---
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_crypto"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"

--- a/tezos-encoding-derive/Cargo.toml
+++ b/tezos-encoding-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_data_encoding_derive"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"

--- a/tezos-encoding/Cargo.toml
+++ b/tezos-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_data_encoding"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Follow up from #26 - which only published `tezos_data_encoding_derive`