### PR TITLE
publish 0.4.3 to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: dry-run (crypto)
         run: cargo publish --dry-run -p tezos_crypto
       - name: publish (crypto)
-        run: cargo publish -p tezos_crypto --token ${CRATES_TOKEN}
+        run: cargo publish -p tezos_crypto_rs --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
       - name: dry-run (derive)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Nothing.
 
+## [0.4.3] - 2023-03-14
+
 ## [0.4.2] - 2023-03-14
 
 ### Changed

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_crypto_rs"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"

--- a/tezos-encoding-derive/Cargo.toml
+++ b/tezos-encoding-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_data_encoding_derive"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"

--- a/tezos-encoding/Cargo.toml
+++ b/tezos-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_data_encoding"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ lazy_static = "1.4"
 
 [dependencies.tezos_crypto_rs]
 path = "../crypto"
-version = "0.4.2"
+version = "0.4.3"
 default-features = false
 
 [dependencies.tezos_data_encoding_derive]
 path = "../tezos-encoding-derive"
-version = "0.4.2"
+version = "0.4.3"
 
 [features]
 


### PR DESCRIPTION
(bump version due to `tezos_data_encoding_derive` published @ 0.4.2)