### PR TITLE
CI: run deploys in separate jobs, allowing retry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - '*'  
 
 jobs:
-  publish:
+  publish-crypto:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,12 +17,25 @@ jobs:
         run: cargo publish -p tezos_crypto_rs --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  publish-derive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.60.0
       - name: dry-run (derive)
         run: cargo publish --dry-run -p tezos_data_encoding_derive
       - name: publish (derive)
         run: cargo publish -p tezos_data_encoding_derive --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  publish-encoding:
+    runs-on: ubuntu-latest
+    needs: [publish-crypto, publish-derive]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.60.0
       - name: dry-run (encoding)
         run: cargo publish --dry-run -p tezos_data_encoding
       - name: publish (encoding)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_crypto_rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "base58",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_data_encoding"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bit-vec",
  "hex",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_data_encoding_derive"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "lazy_static",
  "once_cell",


### PR DESCRIPTION
Before, publishing each crate happened in separate steps within the same job. If `crates.io` didn't update its index fast enough, however, then the final `tezos_crypto_rs` deploy could fail as it wouldn't be able to find it's dependencies yet.

Therefore, we split them into separate jobs, to allow manual retry of publishing if crates.io is slow updating