### PR TITLE
tezos_data_encoding_derive: fix derivations

### DIFF
--- a/tezos-encoding-derive/src/enc.rs
+++ b/tezos-encoding-derive/src/enc.rs
@@ -1,5 +1,6 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-FileCopyrightText: 2023 Nomadic Labs <contact@nomadic-labs.com>
+// SPDX-FileCopyrightText: 2023 TriliTech <contact@trili.tech>
 // SPDX-License-Identifier: MIT
 
 use crate::encoding::*;
@@ -15,8 +16,8 @@ pub fn generate_encoding_for_data(
     let encoding = generate_encoding(&data.encoding);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     quote_spanned! {data.name.span()=>
-        impl #impl_generics tezos_encoding::encoding::HasEncoding for #name #ty_generics #where_clause {
-            fn encoding() -> tezos_encoding::encoding::Encoding {
+        impl #impl_generics tezos_data_encoding::encoding::HasEncoding for #name #ty_generics #where_clause {
+            fn encoding() -> tezos_data_encoding::encoding::Encoding {
                 #encoding
             }
         }
@@ -25,11 +26,13 @@ pub fn generate_encoding_for_data(
 
 pub(crate) fn generate_encoding(encoding: &Encoding) -> TokenStream {
     match encoding {
-        Encoding::Unit => quote!(tezos_encoding::encoding::Encoding::Unit),
+        Encoding::Unit => quote!(tezos_data_encoding::encoding::Encoding::Unit),
         Encoding::Primitive(primitive, span) => generage_primitive_encoding(*primitive, *span),
-        Encoding::Bytes(span) => quote_spanned!(*span=> tezos_encoding::encoding::Encoding::Bytes),
+        Encoding::Bytes(span) => {
+            quote_spanned!(*span=> tezos_data_encoding::encoding::Encoding::Bytes)
+        }
         Encoding::Path(path) => {
-            quote_spanned!(path.span()=> #[allow(clippy::redundant_clone)]<#path as tezos_encoding::encoding::HasEncoding>::encoding().clone())
+            quote_spanned!(path.span()=> #[allow(clippy::redundant_clone)]<#path as tezos_data_encoding::encoding::HasEncoding>::encoding().clone())
         }
         Encoding::String(size, span) => generate_string_encoding(size, *span),
         Encoding::Struct(encoding) => generate_struct_encoding(encoding),
@@ -40,21 +43,25 @@ pub(crate) fn generate_encoding(encoding: &Encoding) -> TokenStream {
         Encoding::Bounded(size, encoding, span) => generate_bounded_encoding(size, encoding, *span),
         Encoding::ShortDynamic(encoding, span) => generate_short_dynamic_encoding(encoding, *span),
         Encoding::Dynamic(size, encoding, span) => generate_dynamic_encoding(size, encoding, *span),
-        Encoding::Zarith(span) => quote_spanned!(*span=> tezos_encoding::encoding::Encoding::Z),
-        Encoding::MuTez(span) => quote_spanned!(*span=> tezos_encoding::encoding::Encoding::Mutez),
+        Encoding::Zarith(span) => {
+            quote_spanned!(*span=> tezos_data_encoding::encoding::Encoding::Z)
+        }
+        Encoding::MuTez(span) => {
+            quote_spanned!(*span=> tezos_data_encoding::encoding::Encoding::Mutez)
+        }
     }
 }
 
 fn generage_primitive_encoding(kind: PrimitiveEncoding, span: Span) -> TokenStream {
     let ident = kind.make_ident(span);
-    quote_spanned!(ident.span()=> tezos_encoding::encoding::Encoding::#ident)
+    quote_spanned!(ident.span()=> tezos_data_encoding::encoding::Encoding::#ident)
 }
 
 fn generate_struct_encoding(encoding: &StructEncoding) -> TokenStream {
     let name_str = encoding.name.to_string();
     let fields_encoding = encoding.fields.iter().filter_map(generate_field_encoding);
     quote_spanned! { encoding.name.span()=>
-        tezos_encoding::encoding::Encoding::Obj(#name_str, vec![
+        tezos_data_encoding::encoding::Encoding::Obj(#name_str, vec![
             #(#fields_encoding),*
         ])
     }
@@ -65,7 +72,7 @@ fn generate_field_encoding(field: &FieldEncoding) -> Option<TokenStream> {
         let name = field.name.to_string();
         let encoding = generate_encoding(&encoding.encoding);
         Some(
-            quote_spanned!(field.name.span()=> tezos_encoding::encoding::Field::new(#name, #encoding)),
+            quote_spanned!(field.name.span()=> tezos_data_encoding::encoding::Field::new(#name, #encoding)),
         )
     } else {
         None
@@ -76,9 +83,9 @@ fn generate_enum_encoding(encoding: &EnumEncoding) -> TokenStream {
     let tag_type = &encoding.tag_type;
     let tags_encoding = encoding.tags.iter().map(generate_tag_encoding);
     quote_spanned! { tag_type.span()=>
-        tezos_encoding::encoding::Encoding::Tags(
+        tezos_data_encoding::encoding::Encoding::Tags(
             std::mem::size_of::<#tag_type>(),
-            tezos_encoding::encoding::TagMap::new(vec![
+            tezos_data_encoding::encoding::TagMap::new(vec![
                 #(#tags_encoding),*
             ])
         )
@@ -89,13 +96,13 @@ fn generate_tag_encoding(tag: &Tag) -> TokenStream {
     let id = &tag.id;
     let name = tag.name.to_string();
     let encoding = generate_encoding(&tag.encoding);
-    quote_spanned!(tag.name.span()=> tezos_encoding::encoding::Tag::new(#id, #name, #encoding))
+    quote_spanned!(tag.name.span()=> tezos_data_encoding::encoding::Tag::new(#id, #name, #encoding))
 }
 
 fn generate_string_encoding(size: &Option<syn::Expr>, span: Span) -> TokenStream {
     size.as_ref().map_or_else(
-        || quote_spanned!(span=> tezos_encoding::encoding::Encoding::String),
-        |size| quote_spanned!(span=> tezos_encoding::encoding::Encoding::BoundedString(#size)),
+        || quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::String),
+        |size| quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::BoundedString(#size)),
     )
 }
 
@@ -105,12 +112,12 @@ fn generate_list_encoding<'a>(
     span: Span,
 ) -> TokenStream {
     let encoding = generate_encoding(encoding);
-    size.as_ref().map_or_else(|| quote_spanned!(span=> tezos_encoding::encoding::Encoding::List(Box::new(#encoding))), |size| quote_spanned!(span=> tezos_encoding::encoding::Encoding::BoundedList(#size, Box::new(#encoding))))
+    size.as_ref().map_or_else(|| quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::List(Box::new(#encoding))), |size| quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::BoundedList(#size, Box::new(#encoding))))
 }
 
 fn generate_optional_field_encoding(encoding: &Encoding, span: Span) -> TokenStream {
     let encoding = generate_encoding(encoding);
-    quote_spanned!(span=> tezos_encoding::encoding::Encoding::OptionalField(Box::new(#encoding)))
+    quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::OptionalField(Box::new(#encoding)))
 }
 
 fn generate_sized_encoding<'a>(
@@ -119,7 +126,7 @@ fn generate_sized_encoding<'a>(
     span: Span,
 ) -> TokenStream {
     let encoding = generate_encoding(encoding);
-    quote_spanned!(span=> tezos_encoding::encoding::Encoding::Sized(#size, Box::new(#encoding)))
+    quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::Sized(#size, Box::new(#encoding)))
 }
 
 fn generate_bounded_encoding<'a>(
@@ -128,12 +135,12 @@ fn generate_bounded_encoding<'a>(
     span: Span,
 ) -> TokenStream {
     let encoding = generate_encoding(encoding);
-    quote_spanned!(span=> tezos_encoding::encoding::Encoding::Bounded(#size, Box::new(#encoding)))
+    quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::Bounded(#size, Box::new(#encoding)))
 }
 
 fn generate_short_dynamic_encoding(encoding: &Encoding, span: Span) -> TokenStream {
     let encoding = generate_encoding(encoding);
-    quote_spanned!(span=> tezos_encoding::encoding::Encoding::ShortDynamic(Box::new(#encoding)))
+    quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::ShortDynamic(Box::new(#encoding)))
 }
 
 fn generate_dynamic_encoding<'a>(
@@ -143,6 +150,6 @@ fn generate_dynamic_encoding<'a>(
 ) -> TokenStream {
     let encoding = generate_encoding(encoding);
     size.as_ref().map_or_else(
-        || quote_spanned!(span=> tezos_encoding::encoding::Encoding::Dynamic(Box::new(#encoding))),
-        |size| quote_spanned!(span=> tezos_encoding::encoding::Encoding::BoundedDynamic(#size, Box::new(#encoding))))
+        || quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::Dynamic(Box::new(#encoding))),
+        |size| quote_spanned!(span=> tezos_data_encoding::encoding::Encoding::BoundedDynamic(#size, Box::new(#encoding))))
 }

--- a/tezos-encoding-derive/src/lib.rs
+++ b/tezos-encoding-derive/src/lib.rs
@@ -1,7 +1,13 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-FileCopyrightText: 2023 Nomadic Labs <contact@nomadic-labs.com>
+// SPDX-FileCopyrightText: 2023 TriliTech <contact@trili.tech>
 // SPDX-License-Identifier: MIT
 #![forbid(unsafe_code)]
+
+//! Automatic derivation of data encodings for rust structures.
+//!
+//! Rather than manually implementing the `NomReader` and `BinWriter` traits, you can
+//! annotate your structures directly.
 
 extern crate proc_macro;
 
@@ -16,7 +22,7 @@ mod nom;
 mod symbol;
 
 #[proc_macro_derive(HasEncoding, attributes(encoding))]
-pub fn derive_tezos_encoding(input: TokenStream) -> TokenStream {
+pub fn derive_tezos_data_encoding(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let encoding = match crate::make::make_encoding(&input) {
         Ok(encoding) => encoding,

--- a/tezos-encoding-derive/src/make.rs
+++ b/tezos-encoding-derive/src/make.rs
@@ -1,5 +1,4 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
-// SPDX-FileCopyrightText: 2023 TriliTech <contact@trili.tech>
 // SPDX-License-Identifier: MIT
 
 use proc_macro2::Span;

--- a/tezos-encoding/src/lib.rs
+++ b/tezos-encoding/src/lib.rs
@@ -4,6 +4,50 @@
 #![cfg_attr(feature = "fuzzing", feature(no_coverage))]
 
 //! This crate provides serialization and deserialization functionality for the data types used by the Tezos shell.
+//!
+//! You can either implement [`NomReader`] and [`BinWriter`] manually, or derive them.
+//!
+//! # Examples
+//!
+//! Let's create encodings for a struct containing two arrays - one of fixed size, and one dynamic.
+//!
+//! Derivation is supported across generic structs.
+//!
+//! ```rust
+//! use tezos_data_encoding::nom::NomReader;
+//! use tezos_data_encoding::enc::BinWriter;
+//! use tezos_data_encoding::encoding::HasEncoding;
+//! # use core::fmt::Debug;
+//!
+//! const INNER_SIZE: usize = 10;
+//!
+//! #[derive(Debug, PartialEq, HasEncoding, NomReader, BinWriter)]
+//! struct Inner {
+//!   #[encoding(sized = "INNER_SIZE", bytes)]
+//!   fixed_size: Vec<u8>
+//! }
+//!
+//! #[derive(Debug, PartialEq, HasEncoding, NomReader, BinWriter)]
+//! struct Outer<T>
+//! where T: Debug + PartialEq + HasEncoding + NomReader + BinWriter {
+//!   #[encoding(dynamic)]
+//!   dynamic_size: Vec<T>
+//! }
+//! #
+//! # let inner_1 = Inner { fixed_size: vec![1; INNER_SIZE] };
+//! # let inner_2 = Inner { fixed_size: vec![2; INNER_SIZE] };
+//! #
+//! # let outer = Outer { dynamic_size: vec![inner_1, inner_2] };
+//! #
+//! # let mut encoded = Vec::new();
+//! # outer.bin_write(&mut encoded).expect("encoding works");
+//! #
+//! # let (_remaining_input, result) = Outer::<Inner>::nom_read(&encoded)
+//! #     .expect("decoding works");
+//! #
+//! # assert!(_remaining_input.is_empty());
+//! # assert_eq!(outer, result);
+//! ```
 
 extern crate tezos_crypto_rs as crypto;
 


### PR DESCRIPTION
Derivations of encodings previously running against the old `tezos_encoding` crate name.

To ensure this doesn't happen again, we add a doc test showcasing derivation to ensure encodings work correctly.