### PR TITLE
crypto: switch to ed25519_dalek

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@stable
       - name: install cargo-audit
         run: cargo install cargo-audit
       - name: audit dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
             sudo apt-get install libhidapi-dev libev4 clang libclang-dev llvm-dev g++
       - name: OSX dependencies
         if: runner.os == 'macOS'
-        run: brew install pkg-config gmp libev hidapi libffi
+        run: brew install pkg-config gmp libev hidapi libffi llvm
       - name: cargo check (default features)
         run: cargo check
       - name: cargo check (no default features)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Nothing.
+- Ed25519 implementation switched from `ed25519_compact` to `ed25519-dalek`.
+- `PublicKeyEd25519::sign` no longer takes an `Iterator`, instead only one `AsRef<u8>` is allowed.
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +181,20 @@ name = "cryptoxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.6",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
+ "subtle",
+]
 
 [[package]]
 name = "der"
@@ -179,6 +212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,14 +230,28 @@ dependencies = [
  "der",
  "elliptic-curve",
  "hmac",
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
-name = "ed25519-compact"
-version = "2.0.4"
+name = "ed25519"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+dependencies = [
+ "signature 2.1.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2 0.10.6",
+]
 
 [[package]]
 name = "either"
@@ -256,6 +313,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fnv"
@@ -349,7 +412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -404,6 +467,12 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
@@ -416,13 +485,13 @@ checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
  "base64",
- "digest",
+ "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -432,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
- "digest",
+ "digest 0.9.0",
  "subtle",
 ]
 
@@ -509,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
+ "libm 0.2.6",
 ]
 
 [[package]]
@@ -542,7 +611,17 @@ checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -569,6 +648,12 @@ dependencies = [
  "regex-syntax",
  "syn",
 ]
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "ppv-lite86"
@@ -808,11 +893,22 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -821,9 +917,15 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 
 [[package]]
 name = "static_assertions"
@@ -906,7 +1008,7 @@ dependencies = [
  "blst",
  "byteorder",
  "cryptoxide",
- "ed25519-compact",
+ "ed25519-dalek",
  "hex",
  "libsecp256k1",
  "num-bigint",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 strum = "0.20"
 strum_macros = "0.20"
 zeroize = { version = "1.5" }
-ed25519-compact = { version ="2.0", default-features = false }
+ed25519-dalek = { version = "2.0.0-rc.2", default-features = false }
 cryptoxide = { version = "0.4.4", default-features = false, features = ["sha2", "blake2"] }
 blst = "0.3.10"
 

--- a/crypto/src/bls.rs
+++ b/crypto/src/bls.rs
@@ -253,7 +253,7 @@ mod tests {
         let sig = BlsSignature(bytes.to_vec());
         let sig = min_pk::Signature::try_from(&sig);
 
-        assert_eq!(sig, Err(CryptoError::InvalidSignature));
+        assert!(matches!(sig, Err(CryptoError::InvalidSignature)));
     }
 
     #[test]
@@ -286,7 +286,7 @@ mod tests {
         let pk = PublicKeyBls(bytes.to_vec());
         let pk = min_pk::PublicKey::try_from(&pk);
 
-        assert_eq!(pk, Err(CryptoError::InvalidPublicKey));
+        assert!(matches!(pk, Err(CryptoError::InvalidPublicKey)));
     }
 
     #[test]
@@ -328,7 +328,7 @@ mod tests {
         let msg_keys = [(&msg[..], &pk)];
         let res = sig.aggregate_verify(&mut msg_keys.into_iter());
 
-        assert_eq!(res, Ok(true));
+        assert!(matches!(res, Ok(true)));
     }
 
     // Values taken from tezt test, that was failing due to public key not being
@@ -409,7 +409,7 @@ mod tests {
         let msg_keys = [(&msg[..], &pk)];
         let res = sig.aggregate_verify(&mut msg_keys.into_iter());
 
-        assert_eq!(res, Ok(false));
+        assert!(matches!(res, Ok(false)));
     }
 
     // Test to ensure that we use the correct hashing scheme to convert between
@@ -463,7 +463,7 @@ mod tests {
 
           let res = sig.aggregate_verify(&mut msg_keys.into_iter());
 
-          assert_eq!(res, Ok(true));
+          assert!(matches!(res, Ok(true)));
       }
 
       #[test]
@@ -490,7 +490,7 @@ mod tests {
 
           let res = sig.aggregate_verify(&mut msg_keys.into_iter());
 
-          assert_eq!(res, Ok(true));
+          assert!(matches!(res, Ok(true)));
       }
 
       #[test]
@@ -505,7 +505,7 @@ mod tests {
 
           let res = sig.aggregate_verify(&mut msg_keys.into_iter());
 
-          assert_eq!(res, Ok(false));
+          assert!(matches!(res, Ok(false)));
       }
     }
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -13,7 +13,7 @@ pub mod bls;
 #[macro_use]
 pub mod hash;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum CryptoError {
     #[error("Invalid crypto key, reason: {reason}")]
     InvalidKey { reason: String },
@@ -33,6 +33,8 @@ pub enum CryptoError {
     Unsupported(&'static str),
     #[error("Algorithm error: `{0}`")]
     AlgorithmError(String),
+    #[error("Ed25519 error: {0}")]
+    Ed25519(ed25519_dalek::SignatureError),
 }
 
 /// Public key that support hashing.


### PR DESCRIPTION
We moved away from `dalek` due to a previous [security issue](https://github.com/hyperledger/ursa/issues/209). 

This has now been fixed, and so we move back to the latest release of dalek, as it runs much faster than `compact`.

*NB* the API of `verify` has changed, to only accept a single `AsRef<[u8]>`, as the hashing is done internally by dalek.