### PR TITLE
crypto: fix the version of blst to 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Nothing.
 
+## [0.5.1] - 2023-09-01
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Fixed the version of `blst` to 0.3.10
+
 ## [0.5.0] - 2023-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fixed the version of `blst` to 0.3.10
+- Set the version of `ed25519-dalek` to 2.0.0
 
 ## [0.5.0] - 2023-05-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,16 +178,29 @@ checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "digest 0.10.6",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version",
  "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -238,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-rc.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -310,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "fnv"
@@ -455,12 +468,6 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
-name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
@@ -569,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm 0.2.6",
+ "libm",
 ]
 
 [[package]]
@@ -603,16 +610,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.9.9",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm 0.1.4",
 ]
 
 [[package]]
@@ -822,6 +819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +858,12 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_crypto_rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base58",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_data_encoding"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bit-vec",
  "bitvec",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_data_encoding_derive"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "lazy_static",
  "once_cell",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_crypto_rs"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"
@@ -27,7 +27,7 @@ strum_macros = "0.20"
 zeroize = { version = "1.5" }
 ed25519-dalek = { version = "2.0.0-rc.2", default-features = false }
 cryptoxide = { version = "0.4.4", default-features = false, features = ["sha2", "blake2"] }
-blst = "0.3.10"
+blst = "=0.3.10"
 
 proptest = { version = "1.1", optional = true }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 strum = "0.20"
 strum_macros = "0.20"
 zeroize = { version = "1.5" }
-ed25519-dalek = { version = "2.0.0-rc.2", default-features = false }
+ed25519-dalek = { version = "2.0.0", default-features = false }
 cryptoxide = { version = "0.4.4", default-features = false, features = ["sha2", "blake2"] }
 blst = "=0.3.10"
 

--- a/tezos-encoding-derive/Cargo.toml
+++ b/tezos-encoding-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_data_encoding_derive"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"

--- a/tezos-encoding/Cargo.toml
+++ b/tezos-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_data_encoding"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["TriliTech <contact@trili.tech>"]
 edition = "2021"
 rust-version = "1.60"
@@ -23,12 +23,12 @@ lazy_static = "1.4"
 
 [dependencies.tezos_crypto_rs]
 path = "../crypto"
-version = "0.5.0"
+version = "0.5.1"
 default-features = false
 
 [dependencies.tezos_data_encoding_derive]
 path = "../tezos-encoding-derive"
-version = "0.5.0"
+version = "0.5.1"
 
 [features]
 


### PR DESCRIPTION
# Context

When creating a new project with Smart Rollup of Tezos, the `bst` dependency of `crypto` is resolved to the version `0.3.11` which does not build to `wasm32-unknown-unknown`

# Solution

Force the version of `blst` to be `0.3.10`. Only this crate can be updated/published, it's not necessary to update the crates that depends on this one, because new projects will automatically use the version 0.5.1 of `crypto`.



