### PR TITLE
tezos-encoding + derive: keep track of lifetime in NomReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Nothing.
+- `tezos_data_encoding`: The `NomReader` trait is now explicitly
+parameterized by the lifetime of the input byte slice.
 
 ### Deprecated
 

--- a/tezos-encoding/src/lib.rs
+++ b/tezos-encoding/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! #[derive(Debug, PartialEq, HasEncoding, NomReader, BinWriter)]
 //! struct Outer<T>
-//! where T: Debug + PartialEq + HasEncoding + NomReader + BinWriter {
+//! where T: Debug + PartialEq + HasEncoding + for<'a> NomReader<'a> + BinWriter {
 //!   #[encoding(dynamic)]
 //!   dynamic_size: Vec<T>
 //! }

--- a/tezos-encoding/src/nom.rs
+++ b/tezos-encoding/src/nom.rs
@@ -226,13 +226,13 @@ pub type NomError<'a> = error::DecodeError<NomInput<'a>>;
 pub type NomResult<'a, T> = nom::IResult<NomInput<'a>, T, NomError<'a>>;
 
 /// Traits defining message decoding using `nom` primitives.
-pub trait NomReader: Sized {
-    fn nom_read(input: &[u8]) -> NomResult<Self>;
+pub trait NomReader<'a>: Sized {
+    fn nom_read(input: &'a [u8]) -> NomResult<'a, Self>;
 }
 
 macro_rules! hash_nom_reader {
     ($hash_name:ident) => {
-        impl NomReader for crypto::hash::$hash_name {
+        impl<'a> NomReader<'a> for crypto::hash::$hash_name {
             #[inline(always)]
             fn nom_read(input: &[u8]) -> NomResult<Self> {
                 map(take(Self::hash_size()), |bytes| {
@@ -270,13 +270,13 @@ hash_nom_reader!(BlsSignature);
 hash_nom_reader!(NonceHash);
 hash_nom_reader!(SmartRollupHash);
 
-impl NomReader for Zarith {
+impl<'a> NomReader<'a> for Zarith {
     fn nom_read(bytes: &[u8]) -> NomResult<Self> {
         map(z_bignum, |big_int| big_int.into())(bytes)
     }
 }
 
-impl NomReader for Mutez {
+impl<'a> NomReader<'a> for Mutez {
     fn nom_read(bytes: &[u8]) -> NomResult<Self> {
         map(n_bignum, |big_uint| {
             BigInt::from_biguint(Sign::Plus, big_uint).into()

--- a/tezos-encoding/src/types.rs
+++ b/tezos-encoding/src/types.rs
@@ -292,7 +292,7 @@ impl<'de, const SIZE: usize> Deserialize<'de> for SizedBytes<SIZE> {
     }
 }
 
-impl<const SIZE: usize> NomReader for SizedBytes<SIZE> {
+impl<'a, const SIZE: usize> NomReader<'a> for SizedBytes<SIZE> {
     fn nom_read(input: &[u8]) -> crate::nom::NomResult<Self> {
         use crate::nom;
         let (input, slice) = nom::sized(SIZE, nom::bytes)(input)?;
@@ -387,7 +387,7 @@ impl HasEncoding for Bytes {
     }
 }
 
-impl NomReader for Bytes {
+impl<'a> NomReader<'a> for Bytes {
     fn nom_read(input: &[u8]) -> crate::nom::NomResult<Self> {
         use crate::nom::bytes;
         let (input, b) = bytes(input)?;


### PR DESCRIPTION
The `NomReader` trait is implicitly parameterized by the lifetime of the input byte slice. This commit makes the quantification on this explicit. This is needed to implement `NomReader` for structures which keep a reference to some slice of the input, for example to implement lazy deserialization.