### PR TITLE
crypto: fix base58 encoding for BlsSignature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ parameterized by the lifetime of the input byte slice.
 - Fix prefix used in `SeedEd25519` encoding.
 - Add explicit prefix check during base58check decoding.
 - Hash input before signing with `SecretKeyEd25519`, to match octez impl.
+- Fix `BlsSignature` base58 check encoding/decoding.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base58"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +97,15 @@ dependencies = [
  "threadpool",
  "which",
  "zeroize",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1006,8 +1009,8 @@ name = "tezos_crypto_rs"
 version = "0.5.2"
 dependencies = [
  "anyhow",
- "base58",
  "blst",
+ "bs58",
  "byteorder",
  "cryptoxide",
  "ed25519-dalek",
@@ -1084,6 +1087,21 @@ checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "typenum"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/trilitech/tezedge.git"
 
 [dependencies]
 anyhow = "1.0"
-base58 = "0.1.0"
+bs58 = { version = "0.5", default-features = false, features = ["alloc"] }
 thiserror = "1.0"
 hex = "0.4"
 libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"] }

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1265,6 +1265,12 @@ mod tests {
             ["BLsk1WTwJFkLU2P57itDq1cgEUqJK7Fwygvtj49vT4HeLfNBXRgpDA"]
         );
 
+        test!(
+            sig_bls,
+            BlsSignature,
+            ["BLsigAmLKnuw12tethjMmotFPaQ6u4XCKrVk6c15dkRXKkjDDjHywbhS3nd4rBT31yrCvvQrS2HntWhDRu7sX8Vvek53zBUwQHqfcHRiVKVj1ehq8CBYs1Z7XW2rkL2XkVNHua4cnvxY7F"]
+        );
+
         test!(ed25519_sig, Ed25519Signature, ["edsigtXomBKi5CTRf5cjATJWSyaRvhfYNHqSUGrn4SdbYRcGwQrUGjzEfQDTuqHhuA8b2d8NarZjz8TRf65WkpQmo423BtomS8Q"]);
 
         test!(generic_sig, Signature, ["sigNCaj9CnmD94eZH9C7aPPqBbVCJF72fYmCFAXqEbWfqE633WNFWYQJFnDUFgRUQXR8fQ5tKSfJeTe6UAi75eTzzQf7AEc1"]);


### PR DESCRIPTION
The current base58 module incorrectly had a `128` char limit set on decoding hashes - too small for `bls sigs`. We raise this limit to the length of `BlsSigs` hashes, which are the longest hashes we support.

fixes #49 