### PR TITLE
crypto: Signature of all zero bytes should be Unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ parameterized by the lifetime of the input byte slice.
 - Hash input before signing with `SecretKeyEd25519`, to match octez impl.
 - Fix `BlsSignature` base58 check encoding/decoding.
 - Fix `SecretKeyEd25519` base58 check encoding/decoding.
+- Fix all zeros signature encoding: should be `Unknown` rather than defaulting to `Ed25519`.
 
 ### Security
 

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -124,3 +124,14 @@ impl ::std::fmt::Display for Signature {
         write!(f, "{}", self.to_base58_check())
     }
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test() {
+        assert_eq!(
+            &super::Signature::try_from([0; 64].to_vec()).unwrap().to_base58_check(),
+            "sigMzJ4GVAvXEd2RjsKGfG2H9QvqTSKCZsuB2KiHbZRGFz72XgF6KaKADznh674fQgBatxw3xdHqTtMHUZAGRprxy64wg1aq"
+        );
+    }
+}


### PR DESCRIPTION
Currently defaults to Ed25519, which does not match octez reference

Fixes #50 