### PR TITLE
crypto: do not make inner hash public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 parameterized by the lifetime of the input byte slice.
 - Altered hashes to implement `AsRef<[u8]>` instead of `AsRef<Vec<u8>>`.
 - Renamed `hash::Signature` to `hash::UnknownSignature`.
+- All hash structs no longer publicly expose the underlying `Hash`. Instead, use `Into<Vec<u8>>` and `AsRef<[u8]>`.
+- `ToBase58Check` no longer returns a `Result` type.
 
 ### Deprecated
 
@@ -25,6 +27,7 @@ parameterized by the lifetime of the input byte slice.
 ### Removed
 
 - Removed legacy `SecretKeyEd25519` encoding.
+- Removed `ToBase58CheckError`.
 
 ### Fixed
 

--- a/crypto/src/base58.rs
+++ b/crypto/src/base58.rs
@@ -24,14 +24,6 @@ pub enum FromBase58CheckError {
     IncorrectBase58Prefix,
 }
 
-/// Possible errors for ToBase58Check
-#[derive(Debug, Error)]
-pub enum ToBase58CheckError {
-    /// Data is too long
-    #[error("data too long")]
-    DataTooLong,
-}
-
 /// Create double hash of given binary data
 fn double_sha256(data: &[u8]) -> [u8; 32] {
     let digest = sha256(data);
@@ -41,7 +33,7 @@ fn double_sha256(data: &[u8]) -> [u8; 32] {
 /// A trait for converting a value to base58 encoded string.
 pub trait ToBase58Check {
     /// Converts a value of `self` to a base58 value, returning the owned string.
-    fn to_base58check(&self) -> Result<String, ToBase58CheckError>;
+    fn to_base58check(&self) -> String;
 }
 
 /// A trait for converting base58check encoded values.
@@ -55,14 +47,14 @@ pub trait FromBase58Check {
 }
 
 impl ToBase58Check for [u8] {
-    fn to_base58check(&self) -> Result<String, ToBase58CheckError> {
+    fn to_base58check(&self) -> String {
         // 4 bytes checksum
         let mut payload = Vec::with_capacity(self.len() + 4);
         payload.extend(self);
         let checksum = double_sha256(self);
         payload.extend(&checksum[..4]);
 
-        Ok(bs58::encode(payload).into_string())
+        bs58::encode(payload).into_string()
     }
 }
 
@@ -99,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_encode() -> Result<(), anyhow::Error> {
-        let decoded = hex::decode("8eceda2f")?.to_base58check().unwrap();
+        let decoded = hex::decode("8eceda2f")?.to_base58check();
         let expected = "QtRAcc9FSRg";
         assert_eq!(expected, &decoded);
 

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -86,7 +86,7 @@ pub enum FromBytesError {
 macro_rules! define_hash {
     ($name:ident) => {
         #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-        pub struct $name(pub Hash);
+        pub struct $name(pub(crate) Hash);
 
         impl $name {
             fn from_bytes(data: &[u8]) -> Result<Self, FromBytesError> {
@@ -473,12 +473,8 @@ impl HashType {
                 hash.extend(self.base58check_prefix());
             }
             hash.extend(data);
-            hash.to_base58check()
-                // currently the error is returned if the input lenght exceeds 128 bytes
-                // that is the limitation of base58 crate, and there are no hash types
-                // exceeding that limit.
-                // TODO: remove this when TE-373 is implemented
-                .map_err(|_| unreachable!("Hash size should not exceed allowed 128 bytes"))
+
+            Ok(hash.to_base58check())
         }
     }
 


### PR DESCRIPTION
This allows ToBase58Check to no longer return results, since we know the hashes will _always_ be correctly constructed.