### PR TITLE
crypto: verify sig should be more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `From<PublicKeySecp256k1>` impl for `ContractTz2Hash`.
 - Add `From<PublicKeyP256>` impl for `ContractTz3Hash`.
 - Add `From<PublicKeyBls>` impl for `ContractTz4Hash`.
+- Add `TryFrom<Signature>` impl for various signature types.
+- Add `PublicKeySignatureVerifier` impl for `PublicKeyBls`.
 
 ### Changed
 
@@ -30,6 +32,7 @@ parameterized by the lifetime of the input byte slice.
   Blake2bError>`, the error was never possible.
 - `tezos_crypto_rs`: `PublicKeyWithHash::pk_hash` now returns `Self::Hash`
   instead of `Result`.
+- `PublicKeySignatureVerifier` now requires the explicitly correct signature kind for the given public key.
 
 ### Deprecated
 


### PR DESCRIPTION
we update `verify_sig` impls to require the specific signature type for the key being used.

To ease use with `Signature` enum, we provide `TryFrom<Signature> for <SigType>` impls.

Closes #52 

*NB* this does slightly the opposite of what was requested in #52. It's addressed, however, as it is much easier now to convert too the correct signature type, to pass through.

The corresponding `PublicKey` type in the SDK, will be able to use this to greater effect, and can indeed receive the more general `Signature` type.

This layout/structure is more in-line with the `signature` module provided in `octez/tezos_crypto`. 