### PR TITLE
deps: upgrade num-bigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ parameterized by the lifetime of the input byte slice.
 - `tezos_crypto_rs`: `PublicKeyWithHash::pk_hash` now returns `Self::Hash`
   instead of `Result`.
 - `PublicKeySignatureVerifier` now requires the explicitly correct signature kind for the given public key.
-- Update `blst` dependency to `0.3.12` to improve RISC-V compatibility
+- Update `blst` dependency to `0.3.12` to improve RISC-V compatibility.
+- Update `num-bigint` dependency to `0.4` to improve WASM compatibility.
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,32 +543,30 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0"
 hex = "0.4"
 libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"] }
 byteorder = "1.4.3"
-num-bigint = { version = "0.3", features = ["serde"] }
+num-bigint = { version = "0.4", default-features = false, features = ["serde"] }
 num-traits = "0.2.8"
 p256 = { version = "0.9", default-features = false, features = ["ecdsa"] }
 rand = { version = "0.7.3", default-features = false }

--- a/tezos-encoding/Cargo.toml
+++ b/tezos-encoding/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/trilitech/tezedge.git"
 bit-vec = "0.6.2"
 thiserror = "1.0"
 hex = "0.4"
-num-bigint = "0.3"
+num-bigint = { version = "0.4", default-features = false }
 num-traits = "0.2.8"
 serde = { version = "1.0", features = ["derive"] }
 nom = "7.1"


### PR DESCRIPTION
Bump `num-bigint -> 0.4`.

Additionally disable default-features. 

This prevents floating point operations being included, which caused issues when targetting wasm