### PR TITLE
encoding: remove hash field kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ parameterized by the lifetime of the input byte slice.
 - `tezos_data_encoding`: Removed unused `DecodeErrorKind::Hash` and
   `DecodeError::hash_error`
 - `tezos_crypto_rs`: Removed unused `Error` type from `PublicKeyWithHash`
+- Removed support for `hash` field attribute when deriving encodings.
 
 ### Fixed
 

--- a/tezos-encoding-derive/src/encoding.rs
+++ b/tezos-encoding-derive/src/encoding.rs
@@ -21,7 +21,6 @@ pub struct StructEncoding<'a> {
 #[derive(Debug)]
 pub enum FieldKind<'a> {
     Encoded(Box<EncodedField<'a>>),
-    Hash,
     Skip,
 }
 

--- a/tezos-encoding-derive/src/make.rs
+++ b/tezos-encoding-derive/src/make.rs
@@ -62,7 +62,6 @@ fn make_fields<'a>(
 fn field_kind<'a, 'b>(meta: &'a [syn::Meta]) -> Option<FieldKind<'b>> {
     meta.iter().find_map(|meta| match meta {
         syn::Meta::Path(path) if path == symbol::SKIP => Some(FieldKind::Skip),
-        syn::Meta::Path(path) if path == symbol::HASH => Some(FieldKind::Hash),
         _ => None,
     })
 }

--- a/tezos-encoding-derive/src/symbol.rs
+++ b/tezos-encoding-derive/src/symbol.rs
@@ -1,4 +1,6 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-FileCopyrightText: 2024 TriliTech <contact@trili.tech>
+//
 // SPDX-License-Identifier: MIT
 
 use std::{
@@ -42,7 +44,6 @@ pub const COMPOSITE: Symbol = Symbol("composite");
 
 /// Attribute name used to mark field/variant as ignored.
 pub const SKIP: Symbol = Symbol("skip");
-pub const HASH: Symbol = Symbol("hash");
 
 /// Attribute used to specify maximal size/lengh.
 pub const MAX: Symbol = Symbol("max");

--- a/tezos-encoding/src/nom.rs
+++ b/tezos-encoding/src/nom.rs
@@ -1,5 +1,6 @@
 // Copyright (c) SimpleStaking, Viable Systems, Nomadic Labs and Tezedge Contributors
-// SPDX-CopyrightText: 2022-2023 TriliTech <contact@trili.tech>
+// SPDX-CopyrightText: 2022-2024 TriliTech <contact@trili.tech>
+//
 // SPDX-License-Identifier: MIT
 
 use bitvec::slice::BitSlice;
@@ -506,7 +507,7 @@ where
     move |input| parser(input).map_err(|e| e.map(|e| e.add_field(name)))
 }
 
-/// Applies the `parser` to the input, addin enum variant context to the error.
+/// Applies the `parser` to the input, adding enum variant context to the error.
 #[inline(always)]
 pub fn variant<'a, O, F>(
     name: &'static str,
@@ -564,17 +565,6 @@ pub fn n_bignum(mut input: NomInput) -> NomResult<BigUint> {
         bitvec.extend_from_bitslice(bitslice);
     }
     Ok((input, BigUint::from_bytes_be(&bitvec.into_vec())))
-}
-
-pub fn hashed<'a, O, F>(mut parser: F) -> impl FnMut(NomInput<'a>) -> NomResult<'a, (O, Vec<u8>)>
-where
-    F: FnMut(NomInput<'a>) -> NomResult<'a, O>,
-{
-    move |input| {
-        let (rest, result) = parser(input)?;
-        let hash = crypto::blake2b::digest_256(&input[..input.len() - rest.len()]);
-        Ok((rest, (result, hash)))
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Remove the `hashed` field kind from data encoding. As far as I can see we've never used this - and does not appear particularly applicable outside of what tezedge may well have been doing in the past as part of the shell work.

This allows swapping the dependency ordering between `tezos_crypto_rs` & `tezos_data_encoding` in #72 