### PR TITLE
backout of commit 07f4c5674c35065a0dca425333f6edffe3f86c38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ parameterized by the lifetime of the input byte slice.
 - `tezos_crypto_rs`: `PublicKeyWithHash::pk_hash` now returns `Self::Hash`
   instead of `Result`.
 - `PublicKeySignatureVerifier` now requires the explicitly correct signature kind for the given public key.
-- Update `blst` dependency to `0.3.12` to improve RISC-V compatibility.
 - Update `num-bigint` dependency to `0.4` to improve WASM compatibility.
 - Minimum supported rust version bumped to `1.64`.
 - `tezos_crypto_rs` now depends on `tezos_data_encoding`, rather than vice-versa.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,13 +88,14 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.12"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
+ "which",
  "zeroize",
 ]
 
@@ -260,6 +261,12 @@ dependencies = [
  "ed25519",
  "sha2 0.10.6",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -1138,6 +1145,17 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -27,7 +27,7 @@ strum_macros = "0.20"
 zeroize = { version = "1.5" }
 ed25519-dalek = { version = "2.0.0", default-features = false }
 cryptoxide = { version = "0.4.4", default-features = false, features = ["sha2", "blake2"] }
-blst = { version = "0.3.12", optional = true }
+blst = { version = "=0.3.10", optional = true }
 
 proptest = { version = "1.1", optional = true }
 


### PR DESCRIPTION
Unfortunately this upgrade turned out to be none-backwards compatible due to an issue in the blst crate

See https://github.com/supranational/blst/issues/227