### PR TITLE
release: v0.6.0 - encoding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish-crypto:
     runs-on: ubuntu-latest
+    needs: [publish-encoding]
+    if: always()
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -32,7 +34,7 @@ jobs:
 
   publish-encoding:
     runs-on: ubuntu-latest
-    needs: [publish-crypto, publish-derive]
+    needs: [publish-derive]
     if: always()
     steps:
       - uses: actions/checkout@v3

--- a/tezos-encoding/Cargo.toml
+++ b/tezos-encoding/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/trilitech/tezedge.git"
 bit-vec = "0.6.2"
 thiserror = "1.0"
 hex = "0.4"
-num-bigint = { version = "0.4", default-features = false }
+num-bigint = { version = "0.4", default-features = false, features = ["serde"] }
 num-traits = "0.2.8"
 serde = { version = "1.0", features = ["derive"] }
 nom.workspace = true


### PR DESCRIPTION
Resolves an issue in the `derive` for `Z`.

verify with: `cargo publish --dry-run -p tezos_data_encoding`